### PR TITLE
Add Github Actions to project

### DIFF
--- a/.github/ci.yml
+++ b/.github/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # Select platform(s)
+        os: [ ubuntu-latest, macos-latest ]
+        # Select compatible Smalltalk image(s)
+        smalltalk: [ Squeak64-trunk, Squeak64-5.3, Squeak64-5.2 ]
+    name: ${{ matrix.smalltalk }} on ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: hpi-swa/setup-smalltalkCI@v1
+        with:
+          smalltalk-version: ${{ matrix.smalltalk }}
+      - run: smalltalkci -s ${{ matrix.smalltalk }}
+        timeout-minutes: 15

--- a/.github/discord_actions.yml
+++ b/.github/discord_actions.yml
@@ -1,0 +1,2 @@
+- name: Actions for Discord
+  uses: Ilshidur/action-discord@0.0.2


### PR DESCRIPTION
##Github Actions
Github actions allow integrations such as the smalltalk CI. As long as we have admin rights we should include as many runners as we need to support our distraught workflow.

Currently added:
Discord actions