### PR TITLE
Connect to TestDataCenter and use generic phone number and Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Make sure you have the current version of Squeak installed.
 ## Running TelegramClient
 In a workspace window execute the command
 
+## Test TelegramClient
+Use this PhoneNumber:  9996621234
+Use this Code:         22222
+
+Make sure that in `TCCAuthHandler` --> `setTDLibParams` `use_test_dc: true` is set. 
+
 ## Building Tdlib
 Tdlib build instructions are available on their Github page. They also have a wonderful build instruction generator available which was the basis for our workflow . [Check it out here.](https://tdlib.github.io/td/build.html)
 

--- a/packages/TelegramClient-Core.package/TCCAuthHandler.class/instance/setTDLibParams.st
+++ b/packages/TelegramClient-Core.package/TCCAuthHandler.class/instance/setTDLibParams.st
@@ -1,12 +1,13 @@
 accessing
 setTDLibParams
 
- 	self client send: '{"@type": "setTdlibParameters", "parameters": {
+self client send: '{"@type": "setTdlibParameters", "parameters": {
                                                         "database_directory": "tdlib",
                                                         "use_message_database": true,
                                                         "use_secret_chats": true,
-                                                        "api_id": 94575,
-                                                        "api_hash": "a3406de8d171bb422bb6ddf3bbd800e2",
+									  "use_test_dc": true,
+                                                        "api_id": 1733417,
+                                                        "api_hash": "bda1c0b38033d2a5f2ce7e8ab06ef31a",
                                                         "system_language_code": "en",
                                                         "device_model": "Desktop",
                                                         "system_version": "', self client specificClient type, '",

--- a/packages/TelegramClient-Core.package/TCCAuthHandler.class/methodProperties.json
+++ b/packages/TelegramClient-Core.package/TCCAuthHandler.class/methodProperties.json
@@ -18,4 +18,4 @@
 		"logout" : "f.w. 6/3/2020 20:41",
 		"sendPhoneNumber:" : "js 5/31/2020 20:09",
 		"setDBEncryptionKey:" : "js 5/28/2020 17:04",
-		"setTDLibParams" : "R.S 5/23/2020 12:22" } }
+		"setTDLibParams" : "LL 6/5/2020 14:06" } }


### PR DESCRIPTION
closes #115 
closes #121 

Added new API-Key

### Important
Usage of your phone number is only activated if your account is registred in testmode.
Do this here: [Register](https://web.telegram.org/?test=1)
Better: Use the phone number and code written in the README.