### PR TITLE
removed trunk

### DIFF
--- a/.github/ci.yml
+++ b/.github/ci.yml
@@ -10,7 +10,8 @@ jobs:
         # Select platform(s)
         os: [ ubuntu-latest, macos-latest ]
         # Select compatible Smalltalk image(s)
-        smalltalk: [ Squeak64-trunk, Squeak64-5.3, Squeak64-5.2 ]
+        # currently not running on Squeak64-trunk to avoid failures
+        smalltalk: [ Squeak64-5.3, Squeak64-5.2 ]
     name: ${{ matrix.smalltalk }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
removed the trunk squeak version because it is not working right now. Investigate further in slack or add `continue on error` in ci.yml if needed.

closes #128 