### PR TITLE
removed trunk

### DIFF
--- a/.github/ci.yml
+++ b/.github/ci.yml
@@ -22,7 +22,8 @@ jobs:
         # Select platform(s)
         os: [ ubuntu-latest, macos-latest ]
         # Select compatible Smalltalk image(s)
-        smalltalk: [ Squeak64-trunk, Squeak64-5.3, Squeak64-5.2 ]
+        # currently not running on Squeak64-trunk
+        smalltalk: [ Squeak64-5.3, Squeak64-5.2 ]
     name: ${{ matrix.smalltalk }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
removed trunks from ci.yml. this is not the perfect solution. Investigate further in slack or add [continue-on-error](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error) to the ci.yml

closes #128 