### PR TITLE
Removed MacOS-Execution from CI

### DIFF
--- a/.github/ci.yml
+++ b/.github/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         # Select platform(s)
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest ]
         # Select compatible Smalltalk image(s)
         # currently not running on Squeak64-trunk
         smalltalk: [ Squeak64-5.3, Squeak64-5.2 ]


### PR DESCRIPTION
closes #170 
removed MacOS from CI because of tdlib-failure-reasons