### PR TITLE
Split linting and testing in different workflows

### DIFF
--- a/.github/workflows/ci-linter.yml
+++ b/.github/workflows/ci-linter.yml
@@ -1,0 +1,20 @@
+name: CI-Lint
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+        smalltalk: [ Squeak64-5.3 ]
+    name: ${{ matrix.smalltalk }} on ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: hpi-swa/setup-smalltalkCI@v1
+        with:
+          smalltalk-version: ${{ matrix.smalltalk }}
+      - run: smalltalkci -s ${{ matrix.smalltalk }} .smalltalk.lint.ston
+        shell: bash
+        timeout-minutes: 15

--- a/.smalltalk.lint.ston
+++ b/.smalltalk.lint.ston
@@ -1,0 +1,14 @@
+SmalltalkCISpec {
+  #preLoading : 'scripts/preLoading.st',
+  #loading : [
+    SCIMetacelloLoadSpec {
+      #baseline : 'TelegramClient',
+      #platforms : [ #squeak ],
+      #directory : 'packages',
+      #load : [ 'tests' ],
+    }
+  ],
+  #testing : {
+    #classes : [ #TCTLinterTests ]
+  }
+}

--- a/.smalltalk.lint.ston
+++ b/.smalltalk.lint.ston
@@ -1,12 +1,16 @@
+  
 SmalltalkCISpec {
-  #preLoading : 'scripts/preLoading.st',
   #loading : [
     SCIMetacelloLoadSpec {
       #baseline : 'TelegramClient',
       #platforms : [ #squeak ],
       #directory : 'packages',
       #load : [ 'tests' ],
+      #useLatestMetacello : true
     }
+  ],
+  #preLoading : [
+    'scripts/preLoading.st'
   ],
   #testing : {
     #classes : [ #TCTLinterTests ]

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -15,7 +15,6 @@ SmalltalkCISpec {
     },
     #exclude : {
       #classes : [ #TCTLinterTests ]
-    },
-    #packages : [ 'TelegramClient-Tests.*' ]
+    }
   }
 }

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -13,6 +13,9 @@ SmalltalkCISpec {
     #coverage : {
       #packages : [ 'TelegramClient-Core.*' ]
     },
+    #exclude : {
+      #classes : [ #TCTLinterTests ]
+    },
     #packages : [ 'TelegramClient-Tests.*' ]
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ os:
   - linux
 
 smalltalk:
-  - Squeak-5.2
+  - Squeak64-5.2

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 <p align="center">
     <a href="https://github.com/hpi-swa-teaching/TelegramClient/commits/" title="Last Commit"><img src="https://img.shields.io/github/last-commit/hpi-swa-teaching/TelegramClient?style=flat"></a>
     <a href="https://github.com/hpi-swa-teaching/TelegramClient/issues" title="Open Issues"><img src="https://img.shields.io/github/issues/hpi-swa-teaching/TelegramClient"></a>
+    <a href="https://github.com/hpi-swa-teaching/TelegramClient/issues" title="issue resolution"><img src="http://isitmaintained.com/badge/resolution/hpi-swa-teaching/TelegramClient.svg"></a>
     <a href="https://github.com/hpi-swa-teaching/TelegramClient/actions" title="Build Status"><img src="https://github.com/hpi-swa-teaching/TelegramClient/workflows/CI/badge.svg?branch=develop"></a>
     <a href="https://github.com/hpi-swa-teaching/TelegramClient/actions" title="Build Status - Lint"><img src="https://github.com/hpi-swa-teaching/TelegramClient/workflows/CI-Lint/badge.svg?branch=develop"></a>
    <a href="https://github.com/hpi-swa-teaching/TelegramClient/stargazers" title="Stars"><img src="https://img.shields.io/github/stars/hpi-swa-teaching/TelegramClient"></a>

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
     <a href="https://github.com/hpi-swa-teaching/TelegramClient/commits/" title="Last Commit"><img src="https://img.shields.io/github/last-commit/hpi-swa-teaching/TelegramClient?style=flat"></a>
     <a href="https://github.com/hpi-swa-teaching/TelegramClient/issues" title="Open Issues"><img src="https://img.shields.io/github/issues/hpi-swa-teaching/TelegramClient"></a>
     <a href="https://github.com/hpi-swa-teaching/TelegramClient/actions" title="Build Status"><img src="https://github.com/hpi-swa-teaching/TelegramClient/workflows/CI/badge.svg?branch=develop"></a>
+    <a href="https://github.com/hpi-swa-teaching/TelegramClient/actions" title="Build Status - Lint"><img src="https://github.com/hpi-swa-teaching/TelegramClient/workflows/CI-Lint/badge.svg?branch=develop"></a>
    <a href="https://github.com/hpi-swa-teaching/TelegramClient/stargazers" title="Stars"><img src="https://img.shields.io/github/stars/hpi-swa-teaching/TelegramClient"></a>
     <a href="./LICENSE" title="License"><img src="https://img.shields.io/github/license/hpi-swa-teaching/TelegramClient"></a>
 </p>
@@ -15,8 +16,13 @@ TeleSqueak is a **Squeak-Client** for the widely used Telegram-Messenger. It aim
 *This Project is part of the "Softwaretechnik" Lecture 2020 at the Hasso Plattner Institute.*
 
 ## CI Status
+### Unit Tests
 Develop: ![CI](https://github.com/hpi-swa-teaching/TelegramClient/workflows/CI/badge.svg?branch=develop)
 Master(Release): ![CI](https://github.com/hpi-swa-teaching/TelegramClient/workflows/CI/badge.svg?branch=master)
+
+### Linting Tests
+Develop: ![CI](https://github.com/hpi-swa-teaching/TelegramClient/workflows/CI-Lint/badge.svg?branch=develop)
+Master(Release): ![CI](https://github.com/hpi-swa-teaching/TelegramClient/workflows/CI-Lint/badge.svg?branch=master)
 
 ## Installation
 Make sure you have the current version of Squeak installed.


### PR DESCRIPTION
closes #176 
The splits the LinterTests and the UnitTests. It improves the clarity