### PR TITLE
Add missing dependencies to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ We currently only support Squeak 5.3.
 
 1. Install the following prerequisites:
    1. **Last compatible FFI version.** For Squeak version 5.3 use `Metacello new configuration: 'FFI'; load.` to install it.
-   2. **JSON** package from [SqueakSource](http://www.squeaksource.com/@bk-et_a4bRLM1tY2/e2OIPIh6).
+   2. **JSON** package from [SqueakSource](http://www.squeaksource.com/JSON.html).
    3. **Animations** package [GitHub](https://github.com/hpi-swa/animations/).
 
 2. Check our [release page](https://github.com/hpi-swa-teaching/TelegramClient/releases) for an online installer in the form of a sar file. Install this sar file in your Squeak image.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,10 @@ TelegramClient is a **Squeak-Client** for the widely used Telegram-Messenger. It
 
 We currently only support Squeak 5.3.
 
-1. Install the last compatible FFI version. For Squeak version 5.3 use `Metacello new configuration: 'FFI'; load.` to install it.
+1. Install the following prerequisites:
+   1. **Last compatible FFI version.** For Squeak version 5.3 use `Metacello new configuration: 'FFI'; load.` to install it.
+   2. **JSON** package from [SqueakSource](http://www.squeaksource.com/@bk-et_a4bRLM1tY2/e2OIPIh6).
+   3. **Animations** package [GitHub](https://github.com/hpi-swa/animations/).
 
 2. Check our [release page](https://github.com/hpi-swa-teaching/TelegramClient/releases) for an online installer in the form of a sar file. Install this sar file in your Squeak image.
 


### PR DESCRIPTION
Closes #303. I edited this in the wiki, too, via https://github.com/hpi-swa-teaching/TelegramClient/wiki/Setup-Guide/a635ea59c0f0241e44bf9359416ccbfd20c3ec84.