### PR TITLE
Display unsupported messages correctly

### DIFF
--- a/packages/TelegramClient-Core.package/TCCChatsHandler.class/instance/handleNewMessage..st
+++ b/packages/TelegramClient-Core.package/TCCChatsHandler.class/instance/handleNewMessage..st
@@ -4,5 +4,4 @@ handleNewMessage: anEvent
 	| message |
 	
 	message := anEvent at: 'message'.
-	((message at: 'content') at: '@type') = 'messageText'
-		ifTrue: [self addNewMessage: message].
+	self addNewMessage: message.

--- a/packages/TelegramClient-Core.package/TCCChatsHandler.class/methodProperties.json
+++ b/packages/TelegramClient-Core.package/TCCChatsHandler.class/methodProperties.json
@@ -11,7 +11,7 @@
 		"defaultMessageLimit" : "js 8/1/2020 18:24",
 		"getChatHistoryFrom:with:limit:" : "js 8/2/2020 13:17",
 		"getChats" : "js 7/31/2020 22:50",
-		"handleNewMessage:" : "js 8/2/2020 21:12",
+		"handleNewMessage:" : "ct 10/7/2020 21:19",
 		"openNewChat:" : "js 8/2/2020 22:27",
 		"remainingMessages" : "js 8/1/2020 16:49",
 		"remainingMessages:" : "js 8/1/2020 16:50",


### PR DESCRIPTION
Make sure unsupported messages are displayed even if the chat is already open when they arrive.

Fixes #306.