### PR TITLE
allow tests to wait on requested events until global test timeout ada…

### DIFF
--- a/packages/TelegramClient-Tests.package/TCTLoggedInTests.class/instance/defaultTimeout.st
+++ b/packages/TelegramClient-Tests.package/TCTLoggedInTests.class/instance/defaultTimeout.st
@@ -1,4 +1,4 @@
 accessing
 defaultTimeout
 
-	^ 40
+	^ 80

--- a/packages/TelegramClient-Tests.package/TCTLoggedInTests.class/instance/testLogout.st
+++ b/packages/TelegramClient-Tests.package/TCTLoggedInTests.class/instance/testLogout.st
@@ -1,6 +1,8 @@
 testing
 testLogout
 
+	self assert: self core authHandler isAuthStateClosed not.
 	self core authHandler logout.
-	10 seconds wait.
-	self assert: self core authHandler isAuthStateClosed.
+	
+	[self core authHandler isAuthStateClosed]
+		whileFalse: [3 seconds wait].

--- a/packages/TelegramClient-Tests.package/TCTLoggedInTests.class/instance/testMessageSending.st
+++ b/packages/TelegramClient-Tests.package/TCTLoggedInTests.class/instance/testMessageSending.st
@@ -3,11 +3,13 @@ testMessageSending
 
 	| testChatId testChatMessages |
 	
-	"Choose any available chat. The Telegram Test Data Center 'periodically wipe[s] all information stored. See TCTTestCore."
+	"Choose any writable chat. The Telegram Test Data Center 'periodically wipe[s] all information stored. See TCTTestCore."
+	[self core chats anySatisfy: [:c | c canSendMessages]]
+		whileFalse: [3 seconds wait.].
 	testChatId := (self core chats detect: [:chat | chat canSendMessages]) id.
 	
 	self core sendMessage: 'TestMessage' to: testChatId.
-	15 seconds wait.
+	10 seconds wait.
 	
 	testChatMessages := (self core chats getChat: testChatId) messages.
 	self assert: (testChatMessages contains: [:aMessage |

--- a/packages/TelegramClient-Tests.package/TCTLoggedInTests.class/methodProperties.json
+++ b/packages/TelegramClient-Tests.package/TCTLoggedInTests.class/methodProperties.json
@@ -4,8 +4,8 @@
 	"instance" : {
 		"core" : "r.s 7/15/2020 18:46",
 		"core:" : "r.s 7/15/2020 18:46",
-		"defaultTimeout" : "RS 5/10/2021 22:05",
+		"defaultTimeout" : "RS 5/17/2021 18:28",
 		"setUp" : "RS 5/10/2021 22:05",
 		"tearDown" : "r.s 7/16/2020 16:54",
-		"testLogout" : "RS 5/10/2021 22:05",
-		"testMessageSending" : "RS 5/10/2021 22:05" } }
+		"testLogout" : "RS 5/17/2021 18:42",
+		"testMessageSending" : "RS 5/17/2021 18:30" } }


### PR DESCRIPTION
Refactors two fail-prone tests to use adaptive timeouts. That means, that they'll wait for a precondition or assertion until it is fulfilled, or until the test times out in total. This allows quicker testing on local devices but also succeeding tests on Github Actions where longer timeouts are needed.