### PR TITLE
Download all necessary files for Windows

### DIFF
--- a/packages/TelegramClient-Core.package/TCCWindowsClient.class/class/downloadArchive.st
+++ b/packages/TelegramClient-Core.package/TCCWindowsClient.class/class/downloadArchive.st
@@ -7,7 +7,8 @@ downloadArchive
 		response := WebClient httpGet: self downloadUrl.
 		stream
 			binary;
-			nextPutAll: response content].
+			nextPutAll: response content.
+		intermediatePath :=  FileDirectory default / 'archive.zip'.].
 	archive := ZipArchive new readFrom: intermediatePath fullName.
 	archive extractAllTo: FileDirectory default.
 	archive close.

--- a/packages/TelegramClient-Core.package/TCCWindowsClient.class/class/downloadArchive.st
+++ b/packages/TelegramClient-Core.package/TCCWindowsClient.class/class/downloadArchive.st
@@ -8,7 +8,7 @@ downloadArchive
 		stream
 			binary;
 			nextPutAll: response content.
-		intermediatePath :=  FileDirectory default / 'archive.zip'.].
+		intermediatePath := FileDirectory default / 'archive.zip'.].
 	archive := ZipArchive new readFrom: intermediatePath fullName.
 	archive extractAllTo: FileDirectory default.
 	archive close.

--- a/packages/TelegramClient-Core.package/TCCWindowsClient.class/class/downloadUrl.st
+++ b/packages/TelegramClient-Core.package/TCCWindowsClient.class/class/downloadUrl.st
@@ -1,4 +1,4 @@
 accessing
 downloadUrl
 
-	^ 'https://github.com/hpi-swa-teaching/tdlib/releases/download/v1.7.0/tdjson.dll'
+	^ 'https://github.com/hpi-swa-teaching/tdlib/releases/download/v1.7.0/tdlib-1.7.0.zip'

--- a/packages/TelegramClient-Core.package/TCCWindowsClient.class/methodProperties.json
+++ b/packages/TelegramClient-Core.package/TCCWindowsClient.class/methodProperties.json
@@ -1,6 +1,6 @@
 {
 	"class" : {
-		"downloadArchive" : "pk 8/6/2021 15:17",
+		"downloadArchive" : "pk 8/6/2021 15:28",
 		"downloadUrl" : "pk 8/6/2021 15:16",
 		"fileName" : "f.w. 7/15/2020 22:04",
 		"moduleName" : "js 8/2/2020 13:21" },

--- a/packages/TelegramClient-Core.package/TCCWindowsClient.class/methodProperties.json
+++ b/packages/TelegramClient-Core.package/TCCWindowsClient.class/methodProperties.json
@@ -1,7 +1,7 @@
 {
 	"class" : {
-		"downloadArchive" : "RK 7/9/2021 15:30",
-		"downloadUrl" : "tr 8/5/2021 09:14",
+		"downloadArchive" : "pk 8/6/2021 15:17",
+		"downloadUrl" : "pk 8/6/2021 15:16",
 		"fileName" : "f.w. 7/15/2020 22:04",
 		"moduleName" : "js 8/2/2020 13:21" },
 	"instance" : {


### PR DESCRIPTION
Replaces the download link of the Windows client with a ZIP archive containing all four libraries needed.