### PR TITLE
Fix buggy message display when receiving answered message before scrolling

### DIFF
--- a/packages/TelegramClient-UI.package/TCUMessage.class/instance/initialize.st
+++ b/packages/TelegramClient-UI.package/TCUMessage.class/instance/initialize.st
@@ -3,12 +3,6 @@ initialize
 
 	super initialize.
 
-	self initializeDefaults.
-	
-	self messageModel isReply ifTrue: [self addReplySnippet].
-	
 	self
-		addSender;
-		addContent;
-		addDate;
-		shrinkToContent.
+		initializeDefaults;
+		initializeSubmorphs

--- a/packages/TelegramClient-UI.package/TCUMessage.class/instance/initializeSubmorphs.st
+++ b/packages/TelegramClient-UI.package/TCUMessage.class/instance/initializeSubmorphs.st
@@ -1,0 +1,10 @@
+initialization
+initializeSubmorphs
+
+	self messageModel isReply ifTrue: [self addReplySnippet].
+	
+	self
+		addSender;
+		addContent;
+		addDate;
+		shrinkToContent.

--- a/packages/TelegramClient-UI.package/TCUMessage.class/instance/updateReplySnippet.st
+++ b/packages/TelegramClient-UI.package/TCUMessage.class/instance/updateReplySnippet.st
@@ -2,4 +2,4 @@ drawing
 updateReplySnippet
 
 	self submorphsDo: #abandon.
-	self initialize.
+	self initializeSubmorphs

--- a/packages/TelegramClient-UI.package/TCUMessage.class/methodProperties.json
+++ b/packages/TelegramClient-UI.package/TCUMessage.class/methodProperties.json
@@ -13,10 +13,11 @@
 		"addReplySnippet" : "rgw 5/12/2022 15:54",
 		"addSender" : "rgw 5/12/2022 15:54",
 		"addText" : "RK 6/23/2021 11:46",
-		"answeredMessageReceived" : "JS 5/27/2022 19:17",
+		"answeredMessageReceived" : "rgw 6/2/2022 10:29",
 		"date" : "TR 6/20/2021 10:59",
-		"initialize" : "rgw 5/12/2022 16:33",
+		"initialize" : "rgw 6/2/2022 10:45",
 		"initializeDefaults" : "JB 6/11/2021 18:23",
+		"initializeSubmorphs" : "rgw 6/2/2022 10:26",
 		"isOutgoing" : "TR 6/20/2021 11:37",
 		"messageColor" : "JB 5/29/2021 21:06",
 		"messageDateText" : "JB 5/17/2021 10:04",
@@ -28,4 +29,4 @@
 		"senderId" : "8/5/2021 21:14:18",
 		"shrinkToContent" : "RK 8/4/2021 11:58",
 		"text" : "RK 6/29/2021 11:18",
-		"updateReplySnippet" : "JS 5/26/2022 16:33" } }
+		"updateReplySnippet" : "rgw 6/2/2022 10:29" } }


### PR DESCRIPTION
This was a known problem before merging #492:

![image](https://user-images.githubusercontent.com/25486288/171590943-e5361cce-9914-49b7-8e85-b3d7502bb18b.png)

This PR fixes the bug. 
