### PR TITLE
Use different datacenter ID and fix failing test to fix CI

### DIFF
--- a/packages/TelegramClientTests-Core.package/TCTCCoreResource.class/instance/isCoreReadyForSetup.st
+++ b/packages/TelegramClientTests-Core.package/TCTCCoreResource.class/instance/isCoreReadyForSetup.st
@@ -1,4 +1,4 @@
 controlling
 isCoreReadyForSetup
 
-	^ self core authenticationHandler isAwaitingPhoneNumber or: [self core authenticationHandler isAuthorizationStateReady]
+	^ self core authenticationHandler isAwaitingPhoneNumber or: [self core authenticationHandler isAuthorizationStateReady or: [self core authenticationHandler isAwaitingAuthPassword]]

--- a/packages/TelegramClientTests-Core.package/TCTCCoreResource.class/methodProperties.json
+++ b/packages/TelegramClientTests-Core.package/TCTCCoreResource.class/methodProperties.json
@@ -6,6 +6,6 @@
 		"core:" : "TR 6/13/2021 14:53",
 		"ensureLoggedIn" : "RS 7/31/2021 15:59",
 		"ensureLoggedOut" : "RS 7/31/2021 15:59",
-		"isCoreReadyForSetup" : "JB 8/4/2021 00:04",
+		"isCoreReadyForSetup" : "rgw 7/1/2022 10:46",
 		"setUp" : "RS 8/3/2021 10:34",
 		"tearDown" : "JB 8/4/2021 00:04" } }

--- a/packages/TelegramClientTests-Core.package/TCTCTestCore.class/instance/loginWithTestData.st
+++ b/packages/TelegramClientTests-Core.package/TCTCTestCore.class/instance/loginWithTestData.st
@@ -4,8 +4,8 @@ loginWithTestData
 	"See https://core.telegram.org/api/auth#test-phone-numbers. Choose random numbers to bypass flood limits."
 	| phoneNumber testX testYYYY |
 
-	testX := $3. "($1 to: $3) atRandom"
-	testYYYY := '1234'. "((1 to: 4) collect: [:i | ($0 to: $9) atRandom]) join"
+	testX := $1. "($1 to: $3) atRandom"
+	testYYYY := '2345'. "((1 to: 4) collect: [:i | ($0 to: $9) atRandom]) join"
 	phoneNumber := '99966' , testX , testYYYY.
 
 	self authenticationHandler sendPhoneNumber: phoneNumber.

--- a/packages/TelegramClientTests-Core.package/TCTCTestCore.class/methodProperties.json
+++ b/packages/TelegramClientTests-Core.package/TCTCTestCore.class/methodProperties.json
@@ -9,4 +9,4 @@
 		"initialize" : "RS 6/13/2021 12:47",
 		"initializeHandlers" : "JB 8/4/2021 21:35",
 		"loggedEventsSatisfying:" : "RS 6/13/2021 17:06",
-		"loginWithTestData" : "rgw 5/11/2022 16:10" } }
+		"loginWithTestData" : "rgw 7/1/2022 11:01" } }

--- a/packages/TelegramClientTests-UI.package/TCTUChatListItemTests.class/instance/setUp.st
+++ b/packages/TelegramClientTests-UI.package/TCTUChatListItemTests.class/instance/setUp.st
@@ -3,4 +3,4 @@ setUp
 
 	self core: (TCTUMockCore newWithTeleClient: TCTMMockTdlibClient new).
 	self core userStore: TCTMMocks mockUserStore.
-	self core chatsHandler chats: (TCTMMocks mockChatsFor: self core).
+	self core chatsHandler chats: (TCTMMocks mockChatsFor: self core)

--- a/packages/TelegramClientTests-UI.package/TCTUChatListItemTests.class/instance/testChatHasPhoto.st
+++ b/packages/TelegramClientTests-UI.package/TCTUChatListItemTests.class/instance/testChatHasPhoto.st
@@ -2,6 +2,6 @@ testing
 testChatHasPhoto
 
 	self core client onRequestType: 'downloadFile' respond: TCTMMocks mockImageResponseJson.
-	self wantsToTest: (TCUChatListItem newWithChat: (self core chatsHandler chats first) width: 500).
+	self wantsToTest: (TCUChatListItem newWithChat: self core chatsHandler chats first width: 500).
 	0.1 seconds wait.
-	self assert: true equals: ((self subject morphs first) submorphs anySatisfy: [:aMorph | aMorph isImageMorph])
+	self assert: (self subject findByClass: ImageMorph) morphs notEmpty.

--- a/packages/TelegramClientTests-UI.package/TCTUChatListItemTests.class/instance/testChatIsNotPinned.st
+++ b/packages/TelegramClientTests-UI.package/TCTUChatListItemTests.class/instance/testChatIsNotPinned.st
@@ -4,5 +4,5 @@ testChatIsNotPinned
 	| chat |
 	chat := (self core chatsHandler chats reject: [:aChat | aChat isPinned]) first.
 	self core chatsHandler updateChatPosition: (TCTMMocks mockUpdateChatPositionEventForNotPinnedChatWithId: chat id).
-	self wantsToTest: (TCUChatListItem newWithChat: chat width: 500).
-	self assertNotReading: 'pinned' in: (self subject)
+	self wantsToTest: (TCUChatListItem newWithChat: chat width: TCUChatsList defaultWidth).
+	self assertNotReading: 'pinned' in: self subject

--- a/packages/TelegramClientTests-UI.package/TCTUChatListItemTests.class/instance/testChatIsPinned.st
+++ b/packages/TelegramClientTests-UI.package/TCTUChatListItemTests.class/instance/testChatIsPinned.st
@@ -4,5 +4,5 @@ testChatIsPinned
 	| chat |
 	chat := (self core chatsHandler chats reject: [:aChat | aChat isPinned]) first.
 	self core chatsHandler updateChatPosition: (TCTMMocks mockUpdateChatPositionEventForPinnedChatWithId: chat id).
-	self wantsToTest: (TCUChatListItem newWithChat: chat width: 500).
-	self assertReading: 'pinned' in: (self subject)
+	self wantsToTest: (TCUChatListItem newWithChat: chat width: TCUChatsList defaultWidth).
+	self assertReading: 'pinned' in: self subject

--- a/packages/TelegramClientTests-UI.package/TCTUChatListItemTests.class/instance/testChatWithoutPhotoHasDefaultPhoto.st
+++ b/packages/TelegramClientTests-UI.package/TCTUChatListItemTests.class/instance/testChatWithoutPhotoHasDefaultPhoto.st
@@ -3,5 +3,5 @@ testChatWithoutPhotoHasDefaultPhoto
 
 	| chat |
 	chat := (self core chatsHandler chats reject: [:aChat | aChat hasPhoto]) first.
-	self wantsToTest: (TCUChatListItem newWithChat: chat width: 500).
-	self assert: true equals: ((self subject morphs first) submorphs anySatisfy: [:aMorph | aMorph isImageMorph])
+	self wantsToTest: (TCUChatListItem newWithChat: chat width: TCUChatsList defaultWidth).
+	self assert: (self subject findByClass: ImageMorph) morphs notEmpty

--- a/packages/TelegramClientTests-UI.package/TCTUChatListItemTests.class/methodProperties.json
+++ b/packages/TelegramClientTests-UI.package/TCTUChatListItemTests.class/methodProperties.json
@@ -2,8 +2,8 @@
 	"class" : {
 		 },
 	"instance" : {
-		"setUp" : "rgw 6/2/2022 16:10",
+		"setUp" : "js 6/30/2022 16:10",
 		"testChatHasPhoto" : "js 6/30/2022 16:01",
-		"testChatIsNotPinned" : "js 6/18/2022 11:02",
-		"testChatIsPinned" : "js 6/18/2022 11:02",
-		"testChatWithoutPhotoHasDefaultPhoto" : "rgw 6/2/2022 16:41" } }
+		"testChatIsNotPinned" : "js 6/30/2022 16:10",
+		"testChatIsPinned" : "js 6/30/2022 16:10",
+		"testChatWithoutPhotoHasDefaultPhoto" : "js 6/30/2022 16:10" } }

--- a/packages/TelegramClientTests-UI.package/TCTUChatListItemTests.class/methodProperties.json
+++ b/packages/TelegramClientTests-UI.package/TCTUChatListItemTests.class/methodProperties.json
@@ -3,7 +3,7 @@
 		 },
 	"instance" : {
 		"setUp" : "rgw 6/2/2022 16:10",
-		"testChatHasPhoto" : "JS 6/11/2022 09:44",
+		"testChatHasPhoto" : "js 6/30/2022 16:01",
 		"testChatIsNotPinned" : "js 6/18/2022 11:02",
 		"testChatIsPinned" : "js 6/18/2022 11:02",
 		"testChatWithoutPhotoHasDefaultPhoto" : "rgw 6/2/2022 16:41" } }

--- a/packages/TelegramClientTests-UI.package/TCTUChatWindowTests.class/instance/messageInputField.st
+++ b/packages/TelegramClientTests-UI.package/TCTUChatWindowTests.class/instance/messageInputField.st
@@ -1,4 +1,4 @@
 accessing
 messageInputField
 
-	^ (self subject findByClass: TextMorph) findByCriteria: [:textMorph | textMorph isLocked not]
+	^ (self subject findByClass: TextMorph) findByCriteria: [:textMorph | textMorph readOnly not and: [textMorph isLocked not]]

--- a/packages/TelegramClientTests-UI.package/TCTUChatWindowTests.class/instance/testSentMessageAppearsInList.st
+++ b/packages/TelegramClientTests-UI.package/TCTUChatWindowTests.class/instance/testSentMessageAppearsInList.st
@@ -7,5 +7,5 @@ testSentMessageAppearsInList
 	self assertReading: TCTMMocks mockText in: self subject.
 	self sendButton click.
 	0.5 seconds wait.
-	self deny: (('*', TCTMMocks mockText, '*') match: (self messageInputField text string)).
+	self deny: (self messageInputField text contains: TCTMMocks mockText).
 	self assertReading: TCTMMocks mockText in: self subject.

--- a/packages/TelegramClientTests-UI.package/TCTUChatWindowTests.class/instance/testSentMessageAppearsInList.st
+++ b/packages/TelegramClientTests-UI.package/TCTUChatWindowTests.class/instance/testSentMessageAppearsInList.st
@@ -7,5 +7,5 @@ testSentMessageAppearsInList
 	self assertReading: TCTMMocks mockText in: self subject.
 	self sendButton click.
 	0.5 seconds wait.
-	self deny: (self messageInputField text contains: TCTMMocks mockText).
+	self deny: (('*', TCTMMocks mockText, '*') match: (self messageInputField text string)).
 	self assertReading: TCTMMocks mockText in: self subject.

--- a/packages/TelegramClientTests-UI.package/TCTUChatWindowTests.class/methodProperties.json
+++ b/packages/TelegramClientTests-UI.package/TCTUChatWindowTests.class/methodProperties.json
@@ -5,4 +5,4 @@
 		"messageInputField" : "JB 7/19/2021 12:41",
 		"sendButton" : "JB 7/19/2021 12:44",
 		"testSelectAndDeselectMessageToReplyTo" : "JS 5/22/2022 19:23",
-		"testSentMessageAppearsInList" : "JB 7/18/2021 13:19" } }
+		"testSentMessageAppearsInList" : "js 6/23/2022 10:00" } }

--- a/packages/TelegramClientTests-UI.package/TCTUChatWindowTests.class/methodProperties.json
+++ b/packages/TelegramClientTests-UI.package/TCTUChatWindowTests.class/methodProperties.json
@@ -2,7 +2,7 @@
 	"class" : {
 		 },
 	"instance" : {
-		"messageInputField" : "JB 7/19/2021 12:41",
+		"messageInputField" : "rgw 7/1/2022 11:32",
 		"sendButton" : "JB 7/19/2021 12:44",
 		"testSelectAndDeselectMessageToReplyTo" : "JS 5/22/2022 19:23",
-		"testSentMessageAppearsInList" : "js 6/23/2022 10:00" } }
+		"testSentMessageAppearsInList" : "rgw 7/1/2022 11:33" } }


### PR DESCRIPTION
This PR fixes our CI pipeline by doing two things:

- Use datacenter 1 instead of datacenter 3. For some reason, the TDLib asks for a password (`authorizationStateWaitPassword`) when trying to test in datacenter 3. Through trial and error, I found out that datacenter 1 works fine. I added some code to `isCoreReadyForSetup` to make this easier to debug in the future.
- Improve the selector for `messageInputField`. As part of #505 we seemed to have broken the selector for `messageInputField` which contained multiple morphs. The tests worked fine back then, but didn't work anymore since some other `TextMorphs` were also selected.