### PR TITLE
Migrationsprozess TDLib

### DIFF
--- a/packages/TelegramClient-Core.package/TCCChat.class/properties.json
+++ b/packages/TelegramClient-Core.package/TCCChat.class/properties.json
@@ -21,8 +21,8 @@
 		"messageDictionary",
 		"selectedReplyToMessageId",
 		"requestedMessages",
-    "photoId",
-    "isPinned"],
+		"photoId",
+		"isPinned" ],
 	"name" : "TCCChat",
 	"pools" : [
 		 ],

--- a/packages/TelegramClient-Core.package/TCCFFIClient.class/class/libraryFilePath.st
+++ b/packages/TelegramClient-Core.package/TCCFFIClient.class/class/libraryFilePath.st
@@ -1,4 +1,4 @@
 accessing
-fileName
+libraryFilePath
 
 	^ self subclassResponsibility

--- a/packages/TelegramClient-Core.package/TCCFFIClient.class/class/moduleName.st
+++ b/packages/TelegramClient-Core.package/TCCFFIClient.class/class/moduleName.st
@@ -3,7 +3,7 @@ moduleName
 
 	| filePath |
 
-	filePath := FileDirectory default / self fileName.
+	filePath := self libraryFilePath.
 
 	filePath exists ifFalse: [
 		FileStream fileNamed: filePath fullName do: [:stream | 

--- a/packages/TelegramClient-Core.package/TCCFFIClient.class/class/tdlibVersion.st
+++ b/packages/TelegramClient-Core.package/TCCFFIClient.class/class/tdlibVersion.st
@@ -1,0 +1,4 @@
+accessing
+tdlibVersion
+
+	^ '1.8.0'

--- a/packages/TelegramClient-Core.package/TCCFFIClient.class/methodProperties.json
+++ b/packages/TelegramClient-Core.package/TCCFFIClient.class/methodProperties.json
@@ -1,9 +1,10 @@
 {
 	"class" : {
 		"downloadUrl" : "r.s 7/13/2020 17:05",
-		"fileName" : "r.s 7/13/2020 17:05",
-		"moduleName" : "LR 6/5/2022 11:00",
-		"newForCurrentOs" : "pk 8/5/2021 17:09" },
+		"libraryFilePath" : "rgw 7/16/2022 17:57",
+		"moduleName" : "rgw 7/16/2022 17:58",
+		"newForCurrentOs" : "pk 8/5/2021 17:09",
+		"tdlibVersion" : "rgw 7/16/2022 17:36" },
 	"instance" : {
 		"create" : "js 6/13/2020 12:53",
 		"free:" : "js 6/13/2020 18:33",

--- a/packages/TelegramClient-Core.package/TCCLinuxClient.class/class/downloadUrl.st
+++ b/packages/TelegramClient-Core.package/TCCLinuxClient.class/class/downloadUrl.st
@@ -1,4 +1,4 @@
 accessing
 downloadUrl
 
-	^ 'https://github.com/rgwohlbold/tdlib/releases/download/v1.8.0/libtdjson.so.1.8.0'
+	^ 'https://github.com/hpi-swa-teaching/tdlib/releases/download/v' , self tdlibVersion , '/libtdjson.so.' , self tdlibVersion

--- a/packages/TelegramClient-Core.package/TCCLinuxClient.class/class/fileName.st
+++ b/packages/TelegramClient-Core.package/TCCLinuxClient.class/class/fileName.st
@@ -1,4 +1,0 @@
-accessing
-fileName
-
-	^ 'libtdjson.so.1.8.0'

--- a/packages/TelegramClient-Core.package/TCCLinuxClient.class/class/libraryFilePath.st
+++ b/packages/TelegramClient-Core.package/TCCLinuxClient.class/class/libraryFilePath.st
@@ -1,0 +1,4 @@
+accessing
+libraryFilePath
+
+	^ FileDirectory default / ('libtdjson.so.' , self tdlibVersion)

--- a/packages/TelegramClient-Core.package/TCCLinuxClient.class/methodProperties.json
+++ b/packages/TelegramClient-Core.package/TCCLinuxClient.class/methodProperties.json
@@ -1,6 +1,8 @@
 {
 	"class" : {
 		"downloadUrl" : "rgw 5/28/2022 13:48",
-		"fileName" : "rgw 6/2/2022 09:27" },
+		"fileName" : "rgw 6/2/2022 09:27",
+		"downloadUrl" : "rgw 7/16/2022 17:40",
+		"libraryFilePath" : "rgw 7/16/2022 17:57" },
 	"instance" : {
 		"type" : "r.s 7/13/2020 17:31" } }

--- a/packages/TelegramClient-Core.package/TCCLinuxClient.class/methodProperties.json
+++ b/packages/TelegramClient-Core.package/TCCLinuxClient.class/methodProperties.json
@@ -1,7 +1,5 @@
 {
 	"class" : {
-		"downloadUrl" : "rgw 5/28/2022 13:48",
-		"fileName" : "rgw 6/2/2022 09:27",
 		"downloadUrl" : "rgw 7/16/2022 17:40",
 		"libraryFilePath" : "rgw 7/16/2022 17:57" },
 	"instance" : {

--- a/packages/TelegramClient-Core.package/TCCMacClient.class/class/downloadUrl.st
+++ b/packages/TelegramClient-Core.package/TCCMacClient.class/class/downloadUrl.st
@@ -1,4 +1,4 @@
 accessing
 downloadUrl
 
-	^ 'https://github.com/rgwohlbold/tdlib/releases/download/v1.8.0/libtdjson.1.8.0.dylib'
+	^ 'https://github.com/hpi-swa-teaching/tdlib/releases/download/v' , self tdlibVersion , '/libtdjson.' , self tdlibVersion , '.dylib'

--- a/packages/TelegramClient-Core.package/TCCMacClient.class/class/fileName.st
+++ b/packages/TelegramClient-Core.package/TCCMacClient.class/class/fileName.st
@@ -1,4 +1,0 @@
-accessing
-fileName
-
-	^ 'libtdjson.1.8.0.dylib'

--- a/packages/TelegramClient-Core.package/TCCMacClient.class/class/libraryFilePath.st
+++ b/packages/TelegramClient-Core.package/TCCMacClient.class/class/libraryFilePath.st
@@ -1,0 +1,4 @@
+accessing
+libraryFilePath
+
+	^ FileDirectory default / ('libtdjson.' , self tdlibVersion , '.dylib')

--- a/packages/TelegramClient-Core.package/TCCMacClient.class/methodProperties.json
+++ b/packages/TelegramClient-Core.package/TCCMacClient.class/methodProperties.json
@@ -1,6 +1,6 @@
 {
 	"class" : {
-		"downloadUrl" : "rgw 6/2/2022 10:11",
-		"fileName" : "rgw 6/2/2022 10:11" },
+		"downloadUrl" : "rgw 7/16/2022 17:41",
+		"libraryFilePath" : "rgw 7/16/2022 17:57" },
 	"instance" : {
 		"type" : "r.s 7/13/2020 17:31" } }

--- a/packages/TelegramClient-Core.package/TCCWindowsClient.class/class/directoryName.st
+++ b/packages/TelegramClient-Core.package/TCCWindowsClient.class/class/directoryName.st
@@ -1,4 +1,4 @@
 accessing
 directoryName
 
-	^ 'tdjson' , self tdlibVersion
+	^ 'tdlib' , self tdlibVersion

--- a/packages/TelegramClient-Core.package/TCCWindowsClient.class/class/directoryName.st
+++ b/packages/TelegramClient-Core.package/TCCWindowsClient.class/class/directoryName.st
@@ -1,0 +1,4 @@
+accessing
+directoryName
+
+	^ 'tdjson' , self tdlibVersion

--- a/packages/TelegramClient-Core.package/TCCWindowsClient.class/class/downloadArchive.st
+++ b/packages/TelegramClient-Core.package/TCCWindowsClient.class/class/downloadArchive.st
@@ -10,6 +10,6 @@ downloadArchive
 			nextPutAll: response content.
 		intermediatePath := FileDirectory default / 'archive.zip'.].
 	archive := ZipArchive new readFrom: intermediatePath fullName.
-	archive extractAllTo: FileDirectory default.
+	archive extractAllTo: FileDirectory default / self directoryName.
 	archive close.
 	intermediatePath delete.

--- a/packages/TelegramClient-Core.package/TCCWindowsClient.class/class/downloadArchive.st
+++ b/packages/TelegramClient-Core.package/TCCWindowsClient.class/class/downloadArchive.st
@@ -3,6 +3,7 @@ downloadArchive
 
 	| intermediatePath archive response |
 	intermediatePath := FileDirectory default / 'archive.zip'.
+	intermediatePath exists ifTrue: [intermediatePath delete].
 	FileStream fileNamed: intermediatePath fullName do: [:stream |
 		response := WebClient httpGet: self downloadUrl.
 		stream

--- a/packages/TelegramClient-Core.package/TCCWindowsClient.class/class/downloadUrl.st
+++ b/packages/TelegramClient-Core.package/TCCWindowsClient.class/class/downloadUrl.st
@@ -1,4 +1,4 @@
 accessing
 downloadUrl
 
-	^ 'https://github.com/rgwohlbold/tdlib/releases/download/v1.8.0/tdlib-1.8.0.zip'
+	^ 'https://github.com/hpi-swa-teaching/tdlib/releases/download/v' , self tdlibVersion , 'tdlib-' , self tdlibVersion , '.zip'

--- a/packages/TelegramClient-Core.package/TCCWindowsClient.class/class/downloadUrl.st
+++ b/packages/TelegramClient-Core.package/TCCWindowsClient.class/class/downloadUrl.st
@@ -1,4 +1,4 @@
 accessing
 downloadUrl
 
-	^ 'https://github.com/hpi-swa-teaching/tdlib/releases/download/v' , self tdlibVersion , 'tdlib-' , self tdlibVersion , '.zip'
+	^ 'https://github.com/hpi-swa-teaching/tdlib/releases/download/v' , self tdlibVersion , '/tdlib-' , self tdlibVersion , '.zip'

--- a/packages/TelegramClient-Core.package/TCCWindowsClient.class/class/fileName.st
+++ b/packages/TelegramClient-Core.package/TCCWindowsClient.class/class/fileName.st
@@ -1,4 +1,0 @@
-accessing
-fileName
-
-	^ 'tdjson.dll'

--- a/packages/TelegramClient-Core.package/TCCWindowsClient.class/class/libraryFilePath.st
+++ b/packages/TelegramClient-Core.package/TCCWindowsClient.class/class/libraryFilePath.st
@@ -1,0 +1,4 @@
+accessing
+libraryFilePath
+
+	^ FileDirectory default / self directoryName / 'tdjson.dll'

--- a/packages/TelegramClient-Core.package/TCCWindowsClient.class/class/moduleName.st
+++ b/packages/TelegramClient-Core.package/TCCWindowsClient.class/class/moduleName.st
@@ -3,7 +3,7 @@ moduleName
 
 	| filePath |
 
-	filePath := FileDirectory default / self fileName.
+	filePath := self libraryFilePath.
 
 	filePath exists ifFalse: [self downloadArchive].
 

--- a/packages/TelegramClient-Core.package/TCCWindowsClient.class/methodProperties.json
+++ b/packages/TelegramClient-Core.package/TCCWindowsClient.class/methodProperties.json
@@ -1,8 +1,9 @@
 {
 	"class" : {
-		"downloadArchive" : "LR 6/5/2022 11:05",
-		"downloadUrl" : "rgw 6/13/2022 10:35",
-		"fileName" : "f.w. 7/15/2020 22:04",
+		"directoryName" : "rgw 7/16/2022 18:27",
+		"downloadArchive" : "rgw 7/16/2022 18:26",
+		"downloadUrl" : "rgw 7/16/2022 18:27",
+		"libraryFilePath" : "7/16/2022 18:23:35",
 		"moduleName" : "js 8/2/2020 13:21" },
 	"instance" : {
 		"type" : "r.s 7/13/2020 17:31" } }

--- a/packages/TelegramClientTests-Core.package/TCTCClientTests.class/instance/testClientConstants.st
+++ b/packages/TelegramClientTests-Core.package/TCTCClientTests.class/instance/testClientConstants.st
@@ -2,5 +2,4 @@ testing
 testClientConstants
 
 	{TCCLinuxClient . TCCWindowsClient . TCCMacClient} do: [:aClientClass |
-		self assert: aClientClass downloadUrl isString.
-		self assert: aClientClass fileName isString].
+		self assert: aClientClass downloadUrl isString].

--- a/packages/TelegramClientTests-Core.package/TCTCClientTests.class/methodProperties.json
+++ b/packages/TelegramClientTests-Core.package/TCTCClientTests.class/methodProperties.json
@@ -2,5 +2,5 @@
 	"class" : {
 		 },
 	"instance" : {
-		"testClientConstants" : "js 8/2/2020 21:34",
+		"testClientConstants" : "rgw 7/16/2022 18:44",
 		"testClientDestroysHandle" : "RS 7/31/2021 16:03" } }


### PR DESCRIPTION
This PR improves the migration process for new TDLib versions. It does a couple of things:

- Change the download path from my GitHub account to the hpi-swa-teaching account
- On Windows, use a directory containing the TDLib version number so that the library is downloaded if the current version does not match the new one
- Provide one location to change the version `TCCFFIClient>>tdlibVersion` to make releasing less error-prone
- Document the migration process (see [Wiki](https://github.com/hpi-swa-teaching/TelegramClient/wiki/TDLib)) 