### PR TITLE
Improve loading performance, remove devMode

### DIFF
--- a/packages/TelegramClient-Core.package/TCCCore.class/instance/receiveLoop.st
+++ b/packages/TelegramClient-Core.package/TCCCore.class/instance/receiveLoop.st
@@ -3,6 +3,5 @@ receiveLoop
 
 	[self isClientAlive] whileTrue: [
 		self update.
-		"FFI freezes the image. Give it time to do something else."
-		10 milliSeconds wait.
-		Processor yield].
+		Processor yield
+	].

--- a/packages/TelegramClient-Core.package/TCCCore.class/instance/update.st
+++ b/packages/TelegramClient-Core.package/TCCCore.class/instance/update.st
@@ -4,6 +4,8 @@ update
 	| event |
 
 	event := self client receive: 0.05.
+	"Short pause to make image more responsive, see https://github.com/hpi-swa-teaching/TelegramClient/pull/412#issuecomment-868465126"
+	event ifNil: [5 milliSeconds wait].
 	event ifNotNil: [
 		[self handleEvent: (TCCEvent newFromTdlibEvent: event)] fork
 	].

--- a/packages/TelegramClient-Core.package/TCCCore.class/methodProperties.json
+++ b/packages/TelegramClient-Core.package/TCCCore.class/methodProperties.json
@@ -37,6 +37,6 @@
 		"sendPhoneNumber:" : "RS 7/31/2021 15:57",
 		"setUserId:" : "pk 8/5/2021 17:05",
 		"tryHandleError:" : "aka 5/21/2022 12:07",
-		"update" : "pk 8/5/2021 17:09",
+		"update" : "rgw 7/24/2022 15:08",
 		"userStore" : "per 7/15/2021 12:56",
 		"userStore:" : "tr 7/25/2021 17:57" } }

--- a/packages/TelegramClient-Core.package/TCCCore.class/methodProperties.json
+++ b/packages/TelegramClient-Core.package/TCCCore.class/methodProperties.json
@@ -29,7 +29,7 @@
 		"loggedInUserId:" : "pk 8/5/2021 17:04",
 		"pendingRequests" : "pk 5/13/2021 09:46",
 		"pendingRequests:" : "pk 5/13/2021 09:46",
-		"receiveLoop" : "per 6/28/2021 16:26",
+		"receiveLoop" : "rgw 7/24/2022 14:56",
 		"registerCallback:" : "pk 8/5/2021 17:04",
 		"searchChat:" : "pk 8/5/2021 16:39",
 		"send:" : "rgw 6/2/2022 09:43",

--- a/packages/TelegramClient-UI.package/TCUChatListItem.class/instance/addPhoto.st
+++ b/packages/TelegramClient-UI.package/TCUChatListItem.class/instance/addPhoto.st
@@ -2,7 +2,6 @@ drawing
 addPhoto
 
 	| promise morph |
-	TCUTelegram devMode ifTrue: [^ self].
 	self chat hasPhoto ifTrue: [
 		promise := self chat core imageStore getFormPromiseFor: self chat photoId.
 		promise >>= [:aForm |

--- a/packages/TelegramClient-UI.package/TCUChatListItem.class/methodProperties.json
+++ b/packages/TelegramClient-UI.package/TCUChatListItem.class/methodProperties.json
@@ -13,7 +13,7 @@
 	"instance" : {
 		"addBorder" : "RK 8/4/2021 12:05",
 		"addLastMessage" : "LR 7/14/2022 11:35",
-		"addPhoto" : "js 6/13/2022 18:09",
+		"addPhoto" : "rgw 7/24/2022 14:48",
 		"addTitle" : "js 6/18/2022 10:55",
 		"chat" : "rs 6/17/2020 21:45",
 		"chat:" : "rs 6/17/2020 21:45",

--- a/packages/TelegramClient-UI.package/TCUChatsList.class/instance/redrawItems.st
+++ b/packages/TelegramClient-UI.package/TCUChatsList.class/instance/redrawItems.st
@@ -1,8 +1,4 @@
 drawing
 redrawItems
 
-	self clearItems.
-	self items: (self chats collect: [:aChat |
-		self createChatListItem: aChat]).
-
-	self items do: [:anItem | self scroller addMorphBack: anItem].
+	self shouldRedraw: true.

--- a/packages/TelegramClient-UI.package/TCUChatsList.class/instance/shouldRedraw..st
+++ b/packages/TelegramClient-UI.package/TCUChatsList.class/instance/shouldRedraw..st
@@ -1,0 +1,4 @@
+accessing
+shouldRedraw: aBoolean
+
+	shouldRedraw := aBoolean

--- a/packages/TelegramClient-UI.package/TCUChatsList.class/instance/shouldRedraw.st
+++ b/packages/TelegramClient-UI.package/TCUChatsList.class/instance/shouldRedraw.st
@@ -1,0 +1,4 @@
+accessing
+shouldRedraw
+
+	^ shouldRedraw

--- a/packages/TelegramClient-UI.package/TCUChatsList.class/instance/step.st
+++ b/packages/TelegramClient-UI.package/TCUChatsList.class/instance/step.st
@@ -1,0 +1,13 @@
+as yet unclassified
+step
+
+	self shouldRedraw ifTrue: [
+		
+		self clearItems.
+		self items: (self chats collect: [:aChat |
+		self createChatListItem: aChat]).
+
+		self items do: [:anItem | self scroller addMorphBack: anItem].
+		
+		self shouldRedraw: false.
+	]

--- a/packages/TelegramClient-UI.package/TCUChatsList.class/instance/stepTime.st
+++ b/packages/TelegramClient-UI.package/TCUChatsList.class/instance/stepTime.st
@@ -1,0 +1,4 @@
+as yet unclassified
+stepTime
+
+	^ 50

--- a/packages/TelegramClient-UI.package/TCUChatsList.class/methodProperties.json
+++ b/packages/TelegramClient-UI.package/TCUChatsList.class/methodProperties.json
@@ -10,7 +10,11 @@
 		"indicateKeyboardFocus" : "per 6/19/2021 13:49",
 		"initialize" : "per 6/24/2021 23:08",
 		"openNewChat:" : "RS 7/17/2021 17:21",
-		"redrawItems" : "LR 7/14/2022 11:21",
+		"redrawItems" : "rgw 7/24/2022 14:43",
 		"selectChat:" : "JB 7/19/2021 12:26",
 		"selectedChat" : "rs 6/13/2020 08:51",
-		"selectedChat:" : "RS 7/17/2021 10:57" } }
+		"selectedChat:" : "RS 7/17/2021 10:57",
+		"shouldRedraw" : "rgw 7/24/2022 14:42",
+		"shouldRedraw:" : "rgw 7/24/2022 14:42",
+		"step" : "rgw 7/24/2022 14:43",
+		"stepTime" : "rgw 7/24/2022 14:44" } }

--- a/packages/TelegramClient-UI.package/TCUChatsList.class/properties.json
+++ b/packages/TelegramClient-UI.package/TCUChatsList.class/properties.json
@@ -7,7 +7,8 @@
 	"commentStamp" : "js 6/13/2020 19:01",
 	"instvars" : [
 		"selectedChat",
-		"chats" ],
+		"chats",
+		"shouldRedraw" ],
 	"name" : "TCUChatsList",
 	"pools" : [
 		 ],

--- a/packages/TelegramClient-UI.package/TCUMessageWrapper.class/instance/addProfilePhoto.st
+++ b/packages/TelegramClient-UI.package/TCUMessageWrapper.class/instance/addProfilePhoto.st
@@ -2,7 +2,6 @@ constructing
 addProfilePhoto
 
 	| promise morph |
-	TCUTelegram devMode ifTrue: [^ self].
 	self message messageModel senderUser hasPhoto ifTrue: [
 		promise := self message messageModel core imageStore getFormPromiseFor: self message messageModel senderUser photoId.
 		promise >>= [:aForm |

--- a/packages/TelegramClient-UI.package/TCUMessageWrapper.class/methodProperties.json
+++ b/packages/TelegramClient-UI.package/TCUMessageWrapper.class/methodProperties.json
@@ -4,7 +4,7 @@
 		"defaultPhotoSize" : "JS 6/11/2022 11:32",
 		"newFromMessage:withWidth:" : "JS 6/11/2022 11:53" },
 	"instance" : {
-		"addProfilePhoto" : "js 6/13/2022 18:09",
+		"addProfilePhoto" : "rgw 7/24/2022 14:48",
 		"initialize" : "JS 6/11/2022 11:40",
 		"message" : "JS 6/11/2022 11:12",
 		"message:" : "JS 6/11/2022 11:13" } }


### PR DESCRIPTION
This PR improves the chat list loading time dramatically. It does two things:

- Do not redraw full chats list on every last message update. This fully redrew the chats list on every event, leading to n^2 drawn items when having n chats. Instead, we set a flag `shouldRedraw` which is checked in `step` every 50ms. In my tests, this does not seem to have any latency disadvantages, while reducing the loading time to ~1s.
- Wait unconditionally only if the last receive timed out. 

[Peek 2022-07-24 15-12.webm](https://user-images.githubusercontent.com/25486288/180648581-e7f672c9-fe74-4d62-a275-291f16ed5687.webm)

