### PR TITLE
New API key

### DIFF
--- a/packages/TelegramClientTests-Core.package/TCTCTestAuthenticationHandler.class/class/defaultApiHash.st
+++ b/packages/TelegramClientTests-Core.package/TCTCTestAuthenticationHandler.class/class/defaultApiHash.st
@@ -1,4 +1,4 @@
 default values
 defaultApiHash
 
-	^ 'bda1c0b38033d2a5f2ce7e8ab06ef31a'
+	^ '4e185ae9b3c3cbd21e9319645af6c12c'

--- a/packages/TelegramClientTests-Core.package/TCTCTestAuthenticationHandler.class/class/defaultApiId.st
+++ b/packages/TelegramClientTests-Core.package/TCTCTestAuthenticationHandler.class/class/defaultApiId.st
@@ -1,4 +1,4 @@
 default values
 defaultApiId
 
-	^ '1733417'
+	^ '3016700'

--- a/packages/TelegramClientTests-Core.package/TCTCTestAuthenticationHandler.class/methodProperties.json
+++ b/packages/TelegramClientTests-Core.package/TCTCTestAuthenticationHandler.class/methodProperties.json
@@ -1,6 +1,6 @@
 {
 	"class" : {
-		"defaultApiHash" : "JB 6/26/2021 17:25",
-		"defaultApiId" : "pk 8/5/2021 17:08" },
+		"defaultApiHash" : "rgw 7/31/2022 16:30",
+		"defaultApiId" : "rgw 7/31/2022 16:30" },
 	"instance" : {
 		"useTestDC" : "rs 6/14/2020 12:41" } }

--- a/packages/TelegramClientTests-Core.package/TCTCTestCore.class/instance/loginWithTestData.st
+++ b/packages/TelegramClientTests-Core.package/TCTCTestCore.class/instance/loginWithTestData.st
@@ -4,7 +4,7 @@ loginWithTestData
 	"See https://core.telegram.org/api/auth#test-phone-numbers. Choose random numbers to bypass flood limits."
 	| phoneNumber testX testYYYY |
 
-	testX := $1. "($1 to: $3) atRandom"
+	testX := $2. "($1 to: $3) atRandom"
 	testYYYY := '2345'. "((1 to: 4) collect: [:i | ($0 to: $9) atRandom]) join"
 	phoneNumber := '99966' , testX , testYYYY.
 

--- a/packages/TelegramClientTests-Core.package/TCTCTestCore.class/methodProperties.json
+++ b/packages/TelegramClientTests-Core.package/TCTCTestCore.class/methodProperties.json
@@ -9,4 +9,4 @@
 		"initialize" : "RS 6/13/2021 12:47",
 		"initializeHandlers" : "JB 8/4/2021 21:35",
 		"loggedEventsSatisfying:" : "RS 6/13/2021 17:06",
-		"loginWithTestData" : "rgw 7/1/2022 11:01" } }
+		"loginWithTestData" : "rgw 7/31/2022 16:38" } }


### PR DESCRIPTION
The current API id and hash used for testing do not seem to work anymore. This PR changes the test id and hash to make the pipeline run again.