### PR TITLE
fix multiple day dividers for same date (messageNotUnderstood in addAtTop)

### DIFF
--- a/packages/TelegramClient-Core.package/TCCChat.class/instance/addNewestMessage..st
+++ b/packages/TelegramClient-Core.package/TCCChat.class/instance/addNewestMessage..st
@@ -2,6 +2,7 @@ adding
 addNewestMessage: aMessage
 
 	| newDate oldDate |
+	self messageIds ifEmpty: [^ self loadChatHistory].
 	newDate := aMessage date asDate.
 	oldDate := self lastMessageDate asDate.
 	(newDate > oldDate) ifTrue: [

--- a/packages/TelegramClient-Core.package/TCCChat.class/instance/addNewestMessage..st
+++ b/packages/TelegramClient-Core.package/TCCChat.class/instance/addNewestMessage..st
@@ -2,13 +2,13 @@ adding
 addNewestMessage: aMessage
 
 	| newDate oldDate |
-	self messageIds ifEmpty: [^ self loadChatHistory].
 	newDate := aMessage date asDate.
 	oldDate := self lastMessageDate asDate.
 	(newDate > oldDate) ifTrue: [
 		aMessage isFirstMessageOfDay: true.
 		self lastMessage isLastMessageOfDay: true.
 		].
+	self messageIds ifEmpty: [aMessage isFirstMessageOfDay: false].
 	self messageIds addFirst: aMessage id.
 	self messageDictionary at: aMessage id put: aMessage.
 	self triggerEvent: #newMessage with: aMessage.

--- a/packages/TelegramClient-Core.package/TCCChat.class/methodProperties.json
+++ b/packages/TelegramClient-Core.package/TCCChat.class/methodProperties.json
@@ -10,7 +10,7 @@
 		"newFromChatEvent:" : "RS 7/17/2021 17:07" },
 	"instance" : {
 		"addAnsweredMessage:" : "JS 5/26/2022 16:41",
-		"addNewestMessage:" : "js 8/4/2022 20:44",
+		"addNewestMessage:" : "js 8/4/2022 20:54",
 		"addOldestMessage:" : "aka 7/14/2022 14:26",
 		"canSendMessages" : "5/11/2021 10:09:15",
 		"canSendMessages:" : "JB 8/4/2021 00:08",

--- a/packages/TelegramClient-Core.package/TCCChat.class/methodProperties.json
+++ b/packages/TelegramClient-Core.package/TCCChat.class/methodProperties.json
@@ -10,7 +10,7 @@
 		"newFromChatEvent:" : "RS 7/17/2021 17:07" },
 	"instance" : {
 		"addAnsweredMessage:" : "JS 5/26/2022 16:41",
-		"addNewestMessage:" : "aka 7/14/2022 14:29",
+		"addNewestMessage:" : "js 8/4/2022 20:44",
 		"addOldestMessage:" : "aka 7/14/2022 14:26",
 		"canSendMessages" : "5/11/2021 10:09:15",
 		"canSendMessages:" : "JB 8/4/2021 00:08",


### PR DESCRIPTION
## Reproduce the failure
- open the telegram client
- send a message in a chat that was not opened before and in which the last message is not from today
- open the chat
- You should get a messageNotUnderstood exception
- If you do the same but with a chat in which the last message is from today you should see two day-dividers with the same date

## Workaround/quickfix for this
- Check if messageIds are empty in addNewestMessage and set isFirstMessageOfDay to false